### PR TITLE
Pager fix

### DIFF
--- a/components/02-molecules/pager/_pager.scss
+++ b/components/02-molecules/pager/_pager.scss
@@ -30,6 +30,10 @@
   }
 }
 
+.pager__link--current {
+  color: $black;
+}
+
 .pager__link--next,
 .pager__link--prev {
   display: block;

--- a/components/02-molecules/pager/pager.twig
+++ b/components/02-molecules/pager/pager.twig
@@ -1,7 +1,7 @@
 {% set pager__base_class = 'pager' %}
 
 {% if posts.pagination.pages is not empty %}
-    <nav  {{ bem(pager__base_class) }} role="navigation">
+    <nav {{ bem(pager__base_class) }} role="navigation">
         <ul {{ bem('items', [], pager__base_class, ['js-pager__items']) }}>
 
             {# First #}
@@ -32,9 +32,14 @@
                     <li {{ bem('item', [], pager__base_class) }}>
                         <a {{ bem('link', [], pager__base_class) }} href="{{ page.link }}">{{ page.title }}</a>
                     </li>
-                {% else %}
+                {# if it is current #}
+                {% elseif page.current == true %}
                     <li {{ bem('item', ['current'], pager__base_class) }}>
                         <span {{ bem('link', ['current'], pager__base_class) }}>{{ page.title }}</span>
+                    </li>
+                {% else %}
+                    <li {{ bem('item', [], pager__base_class) }}>
+                      {{ page.title }}
                     </li>
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
Handling of current item in pager wasn't done correctly. This fixes it to where the current page pager link gets the correct treatment.

PR testing prep:
- `yarn` in theme
- Create a WP site using the Emuslify theme and this branch.

To test:
- [x] Verify in Storybook - `yarn develop` and view [pager](http://localhost:6006/?path=/story/molecules-menus-pager--pager-example) verifying current pager item is highlighted (black color)
- [x] Verify in Wordpress by creating 10 posts that the frontpage content pager is also using the new correction.