### PR TITLE
Fix and style post edit link

### DIFF
--- a/templates/single.twig
+++ b/templates/single.twig
@@ -6,7 +6,9 @@
 			<img src="{{ post.thumbnail.src|resize(1200, 300) }}">
 			<section class="article-content">
 				<h1 class="article-h1">{{ post.title }}</h1>
-				<a href="{{ post.link }}">{{ _e('edit') }}</a>
+        {% if user.can('edit_posts') %}
+				<a href="{{ site.url }}/wp-admin/post.php?post={{ post.id }}&action=edit">{{ _e('edit') }}</a>
+        {% endif %}
 				<p class="blog-author">
 					<span>By</span><a href="{{post.author.path}}"> {{ post.author.name }} </a><span>&bull;</span> <time datetime="{{ post.date|date('Y-m-d H:i:s') }}">{{ post.date }}</time>
 				</p>

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -7,7 +7,11 @@
 			<section class="article-content">
 				<h1 class="article-h1">{{ post.title }}</h1>
         {% if user.can('edit_posts') %}
-				<a href="{{ site.url }}/wp-admin/post.php?post={{ post.id }}&action=edit">{{ _e('edit') }}</a>
+        {% include "@atoms/links/link/link.twig" with {
+          link_base_class: 'button',
+          link_url: site.url ~ '/wp-admin/post.php?post=' ~ post.id ~ '&action=edit',
+          link_content: "Edit Post",
+        } %}
         {% endif %}
 				<p class="blog-author">
 					<span>By</span><a href="{{post.author.path}}"> {{ post.author.name }} </a><span>&bull;</span> <time datetime="{{ post.date|date('Y-m-d H:i:s') }}">{{ post.date }}</time>


### PR DESCRIPTION
Before this change, edit link showed up for all users including non-admins and didn't link anywhere except the post. It now links to the post editing page, only shows up for those with access to edit posts and is styled like a button. 