### PR TITLE
add_attributes Twig function

### DIFF
--- a/components/01-atoms/buttons/twig/button.twig
+++ b/components/01-atoms/buttons/twig/button.twig
@@ -11,7 +11,12 @@
 
 {% set button_base_class = button_base_class|default('button') %}
 
-<button {{ bem(button_base_class, button_modifiers, button_blockname) }}>
+{% set additional_attributes = {
+  class: bem(button_base_class, button_modifiers, button_blockname),
+  role: 'button'
+} %}
+
+<button {{ add_attributes(additional_attributes) }}>
   {% block button_content %}
     {{ button_content }}
   {% endblock %}

--- a/components/01-atoms/buttons/twig/button.twig
+++ b/components/01-atoms/buttons/twig/button.twig
@@ -13,7 +13,6 @@
 
 {% set additional_attributes = {
   class: bem(button_base_class, button_modifiers, button_blockname),
-  role: 'button'
 } %}
 
 <button {{ add_attributes(additional_attributes) }}>

--- a/functions.php
+++ b/functions.php
@@ -209,26 +209,26 @@ class StarterSite extends Timber\Site {
   /**
    * Add Attributes function to pass in multiple attributes including bem style classes.
 	 */
-  public function add_attributes($context, $additional_attributes = []) {
+  public function add_attributes( $context, $additional_attributes = [] ) {
     $attributes = [];
 
-    if (!empty($additional_attributes)) {
-      foreach ($additional_attributes as $key => $value) {
+    if ( ! empty( $additional_attributes ) ) {
+      foreach ( $additional_attributes as $key => $value ) {
         // If there are multiple items in $value as array (e.g., class: ['one', 'two']).
-        if (is_array($value)) {
-          $attributes[] = ($key . '="' . implode(' ', $value) . '"');
+        if ( is_array( $value ) ) {
+          $attributes[] = ( $key . '="' . implode( ' ', $value ) . '"' );
         } else {
           // Handle bem() output (pass in exactly the result).
-          if (strpos($value, '=') !== false) {
+          if ( strpos( $value, '=' ) !== false ) {
             $attributes[] = $value;
           } else {
-            $attributes[] = ($key . '="' . $value . '"');
+            $attributes[] = ( $key . '="' . $value . '"' );
           }
         }
       }
     }
 
-    return implode(' ', $attributes);
+    return implode( ' ', $attributes );
   }
   
 

--- a/functions.php
+++ b/functions.php
@@ -167,7 +167,7 @@ class StarterSite extends Timber\Site {
     }
 
     // Ensure array arguments.
-    if (!is_array($modifiers)) {
+    if (!empty($modifiers) && !is_array($modifiers)) {
       $modifiers = [$modifiers];
     }
     if (!is_array($extra)) {
@@ -206,54 +206,29 @@ class StarterSite extends Timber\Site {
     return $attributes;
   }
 
-  /** Add Attributes function to pass in multiple attributes including bem style classes.
-	 *
+  /**
+   * Add Attributes function to pass in multiple attributes including bem style classes.
 	 */
   public function add_attributes($context, $additional_attributes = []) {
-    $attributes = new Attribute();
+    $attributes = [];
 
     if (!empty($additional_attributes)) {
       foreach ($additional_attributes as $key => $value) {
+        // If there are multiple items in $value as array (e.g., class: ['one', 'two']).
         if (is_array($value)) {
-          foreach ($value as $index => $item) {
-            // Handle bem() output.
-            if ($item instanceof Attribute) {
-              // Remove the item.
-              unset($value[$index]);
-              $value = array_merge($value, $item->toArray()[$key]);
-            }
+          $attributes[] = ($key . '="' . implode(' ', $value) . '"');
+        } else {
+          // Handle bem() output (pass in exactly the result).
+          if (strpos($value, '=') !== false) {
+            $attributes[] = $value;
+          } else {
+            $attributes[] = ($key . '="' . $value . '"');
           }
         }
-        else {
-          // Handle bem() output.
-          if ($value instanceof Attribute) {
-            $value = $value->toArray()[$key];
-          }
-          elseif (is_string($value)) {
-            $value = [$value];
-          }
-          else {
-            continue;
-          }
-        }
-        // Merge additional attribute values with existing ones.
-        if ($context['attributes']->offsetExists($key)) {
-          $existing_attribute = $context['attributes']->offsetGet($key)->value();
-          $value = array_merge($existing_attribute, $value);
-        }
-        $context['attributes']->setAttribute($key, $value);
       }
     }
 
-    // Set all attributes.
-    foreach($context['attributes'] as $key => $value) {
-      $attributes->setAttribute($key, $value);
-      // Remove this attribute from context so it doesn't filter down to child
-      // elements.
-      $context['attributes']->removeAttribute($key);
-    }
-    
-    return $attributes;
+    return implode(' ', $attributes);
   }
   
 


### PR DESCRIPTION
## Purpose:
- Refactors the `add_attributes` Twig function to make it compatible with WordPress

### Functional Testing:
- [ ] Open up the `single.twig` file within the Emulsify theme
- [ ] Add the following code after the `{% if user.can('edit_posts') %}` line:

{% include "@atoms/buttons/twig/button.twig" with {
    button_base_class: 'button',
    button_content: "Edit Post",
    button_modifiers: ['red', 'black']
} %}
- [ ] Verify that the appropriate classes are added to the button element on the frontend:

![Screen Shot 2021-03-24 at 5 29 35 PM](https://user-images.githubusercontent.com/4220469/112385919-9370f980-8cc6-11eb-94bb-a2ce0480170f.png)

- [ ] Open up the `components/01-atoms/buttons/twig/button.twig` file within the Emulsify theme
- [ ] Add one or more attributes to the `additional_attributes` object variable:

{% set additional_attributes = {
  class: bem(button_base_class, button_modifiers, button_blockname),
  *role: 'button',*
  *disabled: 'true',*
} %}

- [ ] On the frontend, verify that the attributes are applied to the button element:

![Screen Shot 2021-03-24 at 5 35 45 PM](https://user-images.githubusercontent.com/4220469/112386489-61ac6280-8cc7-11eb-8dbc-5e540a2929e7.png)
