### PR TITLE
fix(security): enable Twig autoescaping and escape ACF/block context

### DIFF
--- a/.github/scripts/component-locator-smoke.php
+++ b/.github/scripts/component-locator-smoke.php
@@ -408,6 +408,57 @@ try {
 		'ACF block registration should report duplicate normalized final block names.'
 	);
 
+	$registered_card = null;
+
+	foreach ( $GLOBALS['emulsify_locator_acf_registered'] as $registered_block ) {
+		if ( 'emulsify-card' === $registered_block['name'] ) {
+			$registered_card = $registered_block;
+			break;
+		}
+	}
+
+	emulsify_locator_smoke_assert(
+		is_array( $registered_card ) && empty( $registered_card['data']['twig_template'] ),
+		'ACF block registration should not persist the discovered Twig template in block data.'
+	);
+
+	$template_method = new ReflectionMethod( $acf_blocks, 'template' );
+
+	emulsify_locator_smoke_assert(
+		'dist/components/card/card.twig' === $template_method->invoke(
+			$acf_blocks,
+			array(
+				'twig_template' => 'dist/components/card/card.twig',
+				'data'          => array(
+					'twig_template' => 'dist/components/parent-card/parent-card.twig',
+				),
+			)
+		),
+		'ACF block rendering should prefer the registered Twig template over persisted block data.'
+	);
+	emulsify_locator_smoke_assert(
+		'dist/components/parent-card/parent-card.twig' === $template_method->invoke(
+			$acf_blocks,
+			array(
+				'data' => array(
+					'twig_template' => 'dist/components/parent-card/parent-card.twig',
+				),
+			)
+		),
+		'ACF block rendering should allow a legacy persisted template only when component discovery found it.'
+	);
+	emulsify_locator_smoke_assert(
+		'' === $template_method->invoke(
+			$acf_blocks,
+			array(
+				'data' => array(
+					'twig_template' => '../../hostile.twig',
+				),
+			)
+		),
+		'ACF block rendering should reject persisted templates outside the discovered component set.'
+	);
+
 	add_filter(
 		'emulsify_theme_component_discovery_cache_enabled',
 		static function (): bool {

--- a/.github/scripts/pr-validation.cjs
+++ b/.github/scripts/pr-validation.cjs
@@ -42,6 +42,7 @@ run('Run editor enhancements smoke test', 'npm', ['run', 'smoke:editor-enhanceme
 run('Run editor policy smoke test', 'npm', ['run', 'smoke:editor-policy']);
 run('Run pattern registry smoke test', 'npm', ['run', 'smoke:patterns']);
 run('Run parent theme filter smoke test', 'npm', ['run', 'smoke:theme-filters']);
+run('Run Twig autoescape smoke test', 'npm', ['run', 'smoke:twig-autoescape']);
 run('Run Twig switch smoke test', 'npm', ['run', 'smoke:twig-switch']);
 run('Run Twig project namespace smoke test', 'npm', ['run', 'smoke:twig-project-namespace']);
 run('Install Whisk dependencies', 'npm', ['run', 'whisk:install']);

--- a/.github/scripts/release-check.cjs
+++ b/.github/scripts/release-check.cjs
@@ -379,6 +379,7 @@ function runStaticChecks() {
       '.github/scripts/pattern-registry-smoke.php',
       '.github/scripts/wordpress-starter-init-smoke.cjs',
       '.github/scripts/theme-filters-smoke.php',
+      '.github/scripts/twig-autoescape-smoke.php',
       '.github/scripts/twig-project-namespace-smoke.php',
       '.github/scripts/twig-switch-smoke.php',
       '.github/scripts/wordpress-fixture-smoke.cjs',
@@ -496,6 +497,18 @@ function runStaticChecks() {
     return 'Attribute helper runtime and smoke fixture are wired.';
   });
 
+  runStaticCheck('Twig HTML autoescaping', () => {
+    const twig = readFile('includes/Runtime/Twig.php');
+    const smoke = readFile('.github/scripts/twig-autoescape-smoke.php');
+
+    ensure(twig.includes("timber/twig/environment/options"), 'Timber integration should register the Twig environment options filter.');
+    ensure(twig.includes("$options['autoescape'] = 'html'"), 'Timber integration should enable HTML autoescaping.');
+    ensure(smoke.includes('{{ fields.heading }}'), 'Twig autoescape smoke should render a field value.');
+    ensure(smoke.includes('<script>alert(1)</script>'), 'Twig autoescape smoke should use a hostile script fixture.');
+    ensure(smoke.includes("$definition['is_safe']"), 'Twig autoescape smoke should register helper safety metadata.');
+    return 'Twig HTML autoescaping is registered and covered by a behavioral smoke test.';
+  });
+
   runStaticCheck('Twig switch tags', () => {
     const twig = readFile('includes/Runtime/Twig.php');
     const extension = readFile('includes/Twig/SwitchExtension.php');
@@ -596,6 +609,14 @@ function runStaticChecks() {
     ensure(locator.includes('wp_get_environment_type') && locator.includes('WP_DEBUG'), 'Component locator should keep active development uncached unless explicitly enabled.');
     ensure(registry.includes('$components = new ComponentLocator()'), 'Block registry should share one ComponentLocator instance.');
     ensure(acfBlocks.includes('$this->components->acf_components()'), 'ACF/Twig block discovery should use ComponentLocator.');
+    ensure(!acfBlocks.includes("$args['data']['twig_template'] ="), 'ACF/Twig block registration should not persist template paths in editor block data.');
+    ensure(
+      acfBlocks.includes("$block['twig_template']")
+      && acfBlocks.includes("$block['data']['twig_template']")
+      && acfBlocks.indexOf("$block['twig_template']") < acfBlocks.indexOf("$block['data']['twig_template']"),
+      'ACF/Twig rendering should prefer the registered template over persisted block data.'
+    );
+    ensure(smoke.includes('../../hostile.twig'), 'Component locator smoke should prove untrusted persisted template paths are rejected.');
     ensure(acfBlocks.includes('acf_block_name'), 'ACF/Twig block registration should skip duplicate final ACF block names.');
     ensure(acfBlocks.includes('acf_get_block_type'), 'ACF/Twig block registration should avoid already registered ACF block names.');
     ensure(nativeBlocks.includes('$this->components->native_block_directories()'), 'Native block discovery should use ComponentLocator.');
@@ -997,6 +1018,7 @@ function runStaticChecks() {
     ensure(prValidationScript.includes('smoke:patterns'), 'PR validation should run the pattern registry smoke test.');
     ensure(prValidationScript.includes('smoke:starter-init'), 'PR validation should run the WordPress starter init smoke test.');
     ensure(prValidationScript.includes('smoke:theme-filters'), 'PR validation should run the parent theme filter smoke test.');
+    ensure(prValidationScript.includes('smoke:twig-autoescape'), 'PR validation should run the Twig autoescape smoke test.');
     ensure(prValidationScript.includes('smoke:twig-switch'), 'PR validation should run the Twig switch smoke test.');
     ensure(prValidationScript.includes('smoke:twig-project-namespace'), 'PR validation should run the Twig project namespace smoke test.');
     ensure(prValidationScript.includes('whisk:install'), 'PR validation should install Whisk dependencies.');

--- a/.github/scripts/twig-autoescape-smoke.php
+++ b/.github/scripts/twig-autoescape-smoke.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Behavioral smoke coverage for Twig HTML autoescaping.
+ *
+ * @package Emulsify
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "This script must be run from the command line.\n" );
+	exit( 1 );
+}
+
+$autoload = __DIR__ . '/../../vendor/autoload.php';
+
+if ( ! is_readable( $autoload ) ) {
+	fwrite( STDERR, "Composer dependencies are required for the Twig autoescape smoke test.\n" );
+	exit( 1 );
+}
+
+require_once $autoload;
+
+use Emulsify\Theme\Runtime\Twig;
+
+/**
+ * Fails the smoke test with a useful message.
+ *
+ * @param string $message Failure message.
+ * @return void
+ */
+function emulsify_twig_autoescape_fail( string $message ): void {
+	fwrite( STDERR, $message . "\n" );
+	exit( 1 );
+}
+
+$integration = new Twig();
+$options     = $integration->environment_options(
+	array(
+		'autoescape' => false,
+		'cache'      => false,
+	)
+);
+
+if ( 'html' !== $options['autoescape'] || false !== $options['cache'] ) {
+	emulsify_twig_autoescape_fail( 'Twig environment options should enable HTML autoescaping and preserve other options.' );
+}
+
+$environment = new \Twig\Environment(
+	new \Twig\Loader\ArrayLoader(
+		array(
+			'fixture' => '{{ fields.heading }}|{{ add_attributes({class: ["x"]}) }}|{{ bem("card", ["featured"]) }}',
+		)
+	),
+	$options
+);
+
+foreach ( $integration->functions( array() ) as $name => $definition ) {
+	$environment->addFunction(
+		new \Twig\TwigFunction(
+			$name,
+			$definition['callable'],
+			array(
+				'is_safe'       => $definition['is_safe'] ?? array(),
+				'needs_context' => $definition['needs_context'] ?? false,
+			)
+		)
+	);
+}
+
+$integration->extensions( $environment );
+
+$hostile = '"><script>alert(1)</script>';
+$output  = $environment->render(
+	'fixture',
+	array(
+		'fields' => array(
+			'heading' => $hostile,
+		),
+	)
+);
+$expected = '&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;|class="x"|class="card card--featured"';
+
+if ( $expected !== $output ) {
+	emulsify_twig_autoescape_fail(
+		sprintf(
+			"Twig autoescape output was incorrect.\nExpected: %s\nActual:   %s",
+			$expected,
+			$output
+		)
+	);
+}
+
+if ( false !== strpos( $output, '<script>' ) ) {
+	emulsify_twig_autoescape_fail( 'Twig rendered a literal script element from a hostile field value.' );
+}
+
+echo "Twig autoescape smoke checks passed; field values were escaped and attribute helpers remained safe HTML.\n";

--- a/.github/scripts/wordpress-fixture-smoke.cjs
+++ b/.github/scripts/wordpress-fixture-smoke.cjs
@@ -445,8 +445,8 @@ if ( 'dist/components/smoke-acf/smoke-acf.twig' !== $fixture['twig_template'] ) 
   emulsify_smoke_fail( 'Generated child ACF/Twig fixture did not keep its Twig template.' );
 }
 
-if ( empty( $fixture['data']['twig_template'] ) || 'dist/components/smoke-acf/smoke-acf.twig' !== $fixture['data']['twig_template'] ) {
-  emulsify_smoke_fail( 'Generated child ACF/Twig fixture data did not include its Twig template.' );
+if ( ! empty( $fixture['data']['twig_template'] ) ) {
+  emulsify_smoke_fail( 'Generated child ACF/Twig fixture data should not persist its Twig template.' );
 }
 `;
 

--- a/docs/timber-and-twig-authoring.md
+++ b/docs/timber-and-twig-authoring.md
@@ -99,6 +99,23 @@ Then includes such as this resolve through the configured child-theme-relative r
 
 Do not use `theme.json` for Twig namespaces. `theme.json` is WordPress configuration for editor settings, global styles, presets, templates, and style variations; it is not a Twig loader configuration file.
 
+## Escaping and trusted HTML
+
+The parent theme enables Twig's HTML autoescaping for every Timber render path. Component values, including ACF fields and Gutenberg block attributes, are escaped by default:
+
+```twig
+<h2>{{ fields.heading }}</h2>
+```
+
+Use `|raw` only for already-rendered, trusted WordPress HTML. Do not use it to print plain ACF values, block attributes, query parameters, or other editor- or visitor-controlled strings.
+
+```twig
+{{ post.content|raw }}
+{{ comment.content|wpautop|raw }}
+```
+
+The `bem()` and `add_attributes()` helpers build and escape their own attribute values and are registered as safe HTML. Print them directly without `|raw`.
+
 ## Attribute helpers
 
 The parent theme registers Core-style helpers for class and attribute handling:

--- a/includes/Blocks/AcfBlocks.php
+++ b/includes/Blocks/AcfBlocks.php
@@ -250,12 +250,10 @@ final class AcfBlocks {
 			'mode'  => 'preview',
 		);
 
-		$args                          = array_merge( $defaults, $metadata );
-		$args['name']                  = $this->normalize_block_name( $args['name'] ?? '', $component['slug'] );
-		$args['render_callback']       = array( $this, 'render_block' );
-		$args['twig_template']         = $component['template'];
-		$args['data']                  = isset( $args['data'] ) && is_array( $args['data'] ) ? $args['data'] : array();
-		$args['data']['twig_template'] = $component['template'];
+		$args                    = array_merge( $defaults, $metadata );
+		$args['name']            = $this->normalize_block_name( $args['name'] ?? '', $component['slug'] );
+		$args['render_callback'] = array( $this, 'render_block' );
+		$args['twig_template']   = $component['template'];
 
 		return $args;
 	}
@@ -659,16 +657,31 @@ final class AcfBlocks {
 	/**
 	 * Gets the block Twig template.
 	 *
+	 * The top-level value comes from the registered ACF block definition. A
+	 * legacy value persisted in block data is considered only as a fallback, and
+	 * every candidate must match a template found by component discovery.
+	 *
 	 * @param array $block Block settings and attributes.
 	 * @return string Template path.
 	 */
 	private function template( array $block ): string {
-		if ( ! empty( $block['data']['twig_template'] ) && is_string( $block['data']['twig_template'] ) ) {
-			return $block['data']['twig_template'];
-		}
+		$template = '';
 
 		if ( ! empty( $block['twig_template'] ) && is_string( $block['twig_template'] ) ) {
-			return $block['twig_template'];
+			$template = $block['twig_template'];
+		} elseif (
+			! empty( $block['data'] )
+			&& is_array( $block['data'] )
+			&& ! empty( $block['data']['twig_template'] )
+			&& is_string( $block['data']['twig_template'] )
+		) {
+			$template = $block['data']['twig_template'];
+		}
+
+		foreach ( $this->components->acf_components() as $component ) {
+			if ( isset( $component['template'] ) && is_string( $component['template'] ) && $template === $component['template'] ) {
+				return $template;
+			}
 		}
 
 		return '';

--- a/includes/Runtime/Twig.php
+++ b/includes/Runtime/Twig.php
@@ -25,8 +25,25 @@ final class Twig {
 	 */
 	public function register(): void {
 		add_filter( 'timber/loader/loader', array( $this, 'loader_paths' ) );
+		add_filter( 'timber/twig/environment/options', array( $this, 'environment_options' ) );
 		add_filter( 'timber/twig/functions', array( $this, 'functions' ) );
 		add_filter( 'timber/twig', array( $this, 'extensions' ) );
+	}
+
+	/**
+	 * Enables HTML autoescaping for every Timber render path.
+	 *
+	 * Twig context can contain editor-controlled ACF fields and block attributes.
+	 * Escaping by default prevents child templates from turning those values into
+	 * executable markup unless an author explicitly marks trusted HTML as raw.
+	 *
+	 * @param array $options Existing Twig environment options.
+	 * @return array Updated Twig environment options.
+	 */
+	public function environment_options( array $options ): array {
+		$options['autoescape'] = 'html';
+
+		return $options;
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "smoke:patterns": "php .github/scripts/pattern-registry-smoke.php",
     "smoke:starter-init": "node .github/scripts/wordpress-starter-init-smoke.cjs",
     "smoke:theme-filters": "php .github/scripts/theme-filters-smoke.php",
+    "smoke:twig-autoescape": "php .github/scripts/twig-autoescape-smoke.php",
     "smoke:twig-switch": "php .github/scripts/twig-switch-smoke.php",
     "smoke:twig-project-namespace": "php .github/scripts/twig-project-namespace-smoke.php",
     "whisk:build": "npm --prefix whisk run build",

--- a/templates/page.twig
+++ b/templates/page.twig
@@ -24,7 +24,7 @@
             </header>
 
             <div {{ add_attributes(entry_content_attributes) }}>
-                {{ post.content }}
+                {{ post.content|raw }}
             </div>
         </article>
     {% else %}

--- a/templates/partials/comment.twig
+++ b/templates/partials/comment.twig
@@ -26,7 +26,7 @@
         {% endif %}
 
         {% if comment.content|default(null) %}
-            <div {{ add_attributes(comment_content_attributes) }}>{{ comment.content|wpautop }}</div>
+            <div {{ add_attributes(comment_content_attributes) }}>{{ comment.content|wpautop|raw }}</div>
         {% endif %}
 
         {% set children = comment.children|default([]) %}

--- a/templates/partials/tease.twig
+++ b/templates/partials/tease.twig
@@ -31,7 +31,7 @@
 
         {% block summary %}
             {% if post.excerpt|default(null) %}
-                <div {{ add_attributes(teaser_summary_attributes) }}>{{ post.excerpt }}</div>
+                <div {{ add_attributes(teaser_summary_attributes) }}>{{ post.excerpt|raw }}</div>
             {% endif %}
         {% endblock %}
     </article>

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -64,7 +64,7 @@
             </header>
 
             <div {{ add_attributes(entry_content_attributes) }}>
-                {{ post.content }}
+                {{ post.content|raw }}
             </div>
 
             {% set comments = post.comments|default([]) %}


### PR DESCRIPTION
Address S1/S2 from the release review by enabling HTML autoescaping and restricting ACF block template resolution to discovered component templates.

Trusted WordPress HTML remains raw only at:
- templates/single.twig: post.content
- templates/page.twig: post.content
- templates/partials/comment.twig: comment.content|wpautop
- templates/partials/tease.twig: post.excerpt

<!-- 

A similar Pull Request (PR) may already be submitted!

Please search among the PRs before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

- Bug 1
- Bug 2
- Feature 1
- Feature 2
- Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

## Documentation update (required)

If this pull request requires a change to Emulsify documentation, those changes, updates, and/or new information must accompany this pull request.

## How to review this pull request
<!-- Provide step-by-step instructions to functionally test this PR. -->
<!-- Ensure that your code passing the repo's linting standards. -->
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3: Profit

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Closes #
